### PR TITLE
Update smarthome-grafana.js

### DIFF
--- a/web-src/smarthome-grafana.js
+++ b/web-src/smarthome-grafana.js
@@ -95,7 +95,9 @@ function SmartHomeSubscriber(params) {
             throw new Error("addItemListener 'listener' is not a function");
         }
         if (items[itemName] !== undefined) {
-            items[itemName].listeners.push(listener);
+            if( !items[itemName].listeners.includes(listener) ) {
+                items[itemName].listeners.push(listener);
+            }
         } else {
             items[itemName] = {listeners: [listener], value: undefined};
         }


### PR DESCRIPTION
avoid to register the same listener twice. 

It happens if you use panelItem, panelItemFunction, fromItem, fromItemFunction and the values of panelItem and fromItem are the same.

I use it to have different panel depending of the selected time range.